### PR TITLE
Logo links to webpage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
 
   <!-- HEADER -->
   <section class="header">
-    <img src="images/og_image.png" />
+    <a href="https://www.claphelp.life" ><img src="images/og_image.png" /></a>
   </section>
   <!-- /HEADER-->
 


### PR DESCRIPTION
The ClapHelp logo links to "https://claphelp.com"